### PR TITLE
Set vmpool host with a guc vmpool_url

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -80,6 +80,9 @@ MemoryContext CdbComponentsContext = NULL;
 bool		  assignedInstance = false;
 static CdbComponentDatabases *cdb_component_dbs = NULL;
 
+char   *vmpool_url = NULL;
+char	vmpool_url_data[NAMEDATALEN];
+
 /*
  * Helper Functions
  */
@@ -385,10 +388,12 @@ readGpSegConfigFromVmPool(int *total_dbs, bool load)
 		else
 			cJSON_AddFalseToObject(root, "load");
 
+		char url[MAXFNAMELEN];
 		char *json_data = cJSON_Print(root); // 将JSON对象转换为字符串
 
 		// Set the URL to request
-		curl_easy_setopt(curl, CURLOPT_URL, "http://127.0.0.1:5000/cluster");
+		sprintf(url, "%s/cluster", vmpool_url);
+		curl_easy_setopt(curl, CURLOPT_URL, url);
 		curl_easy_setopt(curl, CURLOPT_POST, 1L); // 设置为POST请求
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_data); // 设置POST数据
 
@@ -468,10 +473,13 @@ releaseSegmentConfigs(void)
 
 		cJSON_AddItemToObject(root, "executors", executorList);
 
+		char url[MAXFNAMELEN];
 		char *json_data = cJSON_Print(root); // 将JSON对象转换为字符串
 
+
 		// Set the URL to request
-		curl_easy_setopt(curl, CURLOPT_URL, "http://127.0.0.1:5000/release");
+		sprintf(url, "%s/release", vmpool_url);
+		curl_easy_setopt(curl, CURLOPT_URL, url);
 		curl_easy_setopt(curl, CURLOPT_POST, 1L); // 设置为POST请求
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_data); // 设置POST数据
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -4336,6 +4336,17 @@ static struct config_string ConfigureNamesString[] =
 		NULL, NULL, NULL
 	},
 
+	{
+		{"vmpool_url", PGC_POSTMASTER, PROCESS_TITLE,
+			gettext_noop("Sets the url of the vmpool."),
+			NULL,
+			GUC_IS_NAME
+		},
+		&vmpool_url,
+		"http://127.0.0.1:5000",
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, NULL, NULL, NULL, NULL

--- a/src/bin/vmpool/cs_init.py
+++ b/src/bin/vmpool/cs_init.py
@@ -11,7 +11,7 @@ def init_catalog_server(hostname, port, datadir, s3_url):
         print("PGHOME not set")
         sys.exit(1)
 
-    remote_command.create_minio_bucket("dbdata1")
+    remote_command.create_minio_bucket("dbdata1", s3_url)
     cmd = "%s/bin/initdb -D %s" %(gp_home, datadir)
     print("cmd: %s\n" % cmd)
     remote_command.command_run(cmd, hostname)

--- a/src/bin/vmpool/cs_init.py
+++ b/src/bin/vmpool/cs_init.py
@@ -62,6 +62,7 @@ if __name__ == '__main__':
         help='the url of s3'
     )
 
+
     args = parser.parse_args()
 
     init_catalog_server(args.hostname, args.port, args.datadir, args.s3_url)

--- a/src/bin/vmpool/pool.py
+++ b/src/bin/vmpool/pool.py
@@ -4,6 +4,9 @@ from flask import Flask, jsonify, request
 import os
 import pool_keeper_util
 import heapq
+import argparse
+import socket
+
 
 app = Flask(__name__)
 
@@ -108,6 +111,10 @@ def test():
     min_items = heapq.nsmallest(2, test_data.items(), key=lambda x: x[1]['load'])
     return jsonify(min_items), 200
 
-
 if __name__ == '__main__':
-    app.run(debug=True)
+    parser = argparse.ArgumentParser(
+        description='init the catalog server',
+        epilog='example: cs_init hostname port datadir'
+    )
+
+    app.run(host=socket.gethostname(), port=5000, debug=True)

--- a/src/bin/vmpool/pool_destroy.py
+++ b/src/bin/vmpool/pool_destroy.py
@@ -8,7 +8,7 @@ import requests
 import remote_command
 
 def destroy_pool():
-    url = "http://127.0.0.1:5000/items"
+    url = "http://%s:%s/items" % (remote_command.vmpool_hostname, remote_command.vmpool_port)
     try:
         gp_home = os.getenv("GPHOME")
         if gp_home is None:

--- a/src/bin/vmpool/pool_start.py
+++ b/src/bin/vmpool/pool_start.py
@@ -7,7 +7,7 @@ import requests
 import remote_command
 
 def start_all():
-    url = "http://127.0.0.1:5000/items"
+    url = "http://%s:%s/items" % (remote_command.vmpool_hostname, remote_command.vmpool_port)
     try:
         gp_home = os.getenv("GPHOME")
         if gp_home is None:

--- a/src/bin/vmpool/pool_stop.py
+++ b/src/bin/vmpool/pool_stop.py
@@ -7,7 +7,7 @@ import requests
 import remote_command
 
 def stop_all():
-    url = "http://127.0.0.1:5000/items"
+    url = "http://%s:%s/items" % (remote_command.vmpool_hostname, remote_command.vmpool_port)
     try:
         gp_home = os.getenv("GPHOME")
         if gp_home is None:

--- a/src/bin/vmpool/remote_command.py
+++ b/src/bin/vmpool/remote_command.py
@@ -148,11 +148,11 @@ def remove_one_instance(hostname, datadir):
     except Exception as e:
         print(f"发生未知错误：{str(e)}")
 
-def create_minio_bucket(bucket_name):
+def create_minio_bucket(bucket_name, s3_url):
     # 连接到 MinIO 服务器
     s3_client = boto3.client(
         "s3",
-        endpoint_url="http://192.168.103.130:9000",  # MinIO 服务器地址和端口
+        endpoint_url=s3_url,  # MinIO 服务器地址和端口
         region_name="us-east-1",  # 可任意指定（MinIO 不强制要求）
         aws_access_key_id = "minioadmin",  # MINIO_ROOT_USER
         aws_secret_access_key = "minioadmin"  # MINIO_ROOT_PASSWORD

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -25,6 +25,8 @@ struct SegmentDatabaseDescriptor;
 
 extern MemoryContext CdbComponentsContext;
 extern bool			 assignedInstance;
+extern char	   *vmpool_url;
+extern char		vmpool_url_data[NAMEDATALEN];
 
 typedef struct CdbComponentDatabaseInfo CdbComponentDatabaseInfo;
 typedef struct CdbComponentDatabases CdbComponentDatabases;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -547,6 +547,7 @@
 		"update_process_title",
 		"vacuum_cost_limit",
 		"vacuum_defer_cleanup_age",
+		"vmpool_url",
 		"wait_for_replication_threshold",
 		"wal_block_size",
 		"wal_buffers",


### PR DESCRIPTION
We use localhost as the hostname of pool keeper before. Now, a guc was
added to instance so that user could set the host of pool keeper. It
will help user to deploy the vm pool distributed
