### PR TITLE
Use multiple catalog server in one vmpool

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -365,7 +365,7 @@ bool		gp_cost_hashjoin_chainwalk = false;
  */
 GpId		GpIdentity = {UNINITIALIZED_GP_IDENTITY_VALUE, UNINITIALIZED_GP_IDENTITY_VALUE};
 int			myClusterId = 0;
-int			CatalogServerId = 0;
+char	   *CatalogServerId = NULL;
 int			sessionClusterId = 0;
 int			cluster_size = 3;
 

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -949,7 +949,7 @@ _outCdbCatalogNode(StringInfo str, const CdbCatalogNode *node)
 	WRITE_UINT64_FIELD(seq);
 	WRITE_OID_FIELD(namespace_1);
 	WRITE_OID_FIELD(namespace_2);
-	WRITE_INT_FIELD(CatalogServerId);
+	WRITE_STRING_FIELD(CatalogServerId);
 	WRITE_NODE_FIELD(tableList);
 	WRITE_STRING_FIELD(s3Url);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1697,7 +1697,7 @@ _readCdbCatalogNode(void)
 	READ_UINT64_FIELD(seq);
 	READ_OID_FIELD(namespace_1);
 	READ_OID_FIELD(namespace_2);
-	READ_INT_FIELD(CatalogServerId);
+	READ_STRING_FIELD(CatalogServerId);
 	READ_NODE_FIELD(tableList);
 	READ_STRING_FIELD(s3Url);
 

--- a/src/backend/storage/object/objectfilerw.cpp
+++ b/src/backend/storage/object/objectfilerw.cpp
@@ -27,20 +27,19 @@ typedef struct S3Access
 } S3Access;
 
 extern int myClusterId;
-extern int CatalogServerId;
+extern char *CatalogServerId;
 
 char default_bucket_name[NAMEDATALEN];
-int	bucket_id = 0;
+char *bucket_id = NULL;
 char *s3_url = "127.0.0.1:9000";
 char s3_url_data[NAMEDATALEN];
 
 static void  SetCofig(ClientConfiguration *conf);
 
 void
-S3SetBucketId(int id)
+S3SetBucketId(char *id)
 {
-	bucket_id = id;
-	sprintf(default_bucket_name, "dbdata%d", bucket_id);
+	sprintf(default_bucket_name, "dbdata-%s", id);
 }
 
 void *
@@ -60,7 +59,6 @@ S3InitAccess()
 	if (myClusterId == 0)
 	{
 		S3SetBucketId(CatalogServerId);
-		sprintf(default_bucket_name, "dbdata%d", bucket_id);
 	}
 
 	return static_cast<void*>(s3client);

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3575,13 +3575,24 @@ static struct config_string ConfigureNamesString[] =
 	},
 
 	{
-			{"catalog_server_port", PGC_BACKEND, GP_WORKER_IDENTITY,
-			gettext_noop("Sets the shell command that will be called to archive a WAL file."),
+		{"catalog_server_port", PGC_BACKEND, GP_WORKER_IDENTITY,
+			gettext_noop("The port of catalog server."),
 			NULL,
 			GUC_NOT_IN_SAMPLE
 		},
 		&cs_port,
 		"5432",
+		NULL, NULL, NULL
+	},
+
+	{
+		{"catalog_server_host", PGC_BACKEND, GP_WORKER_IDENTITY,
+			gettext_noop("The host of catalog server."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&cs_host_name,
+		"localhost",
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3295,17 +3295,6 @@ static struct config_int ConfigureNamesInt[] =
 		NULL, NULL, NULL
 	},
 
-	{
-		{"catalog_server_id", PGC_USERSET, CLIENT_CONN_OTHER,
-		 gettext_noop("Sets the cluster id of warehouse."),
-		 NULL,
-		 GUC_UNIT_MS
-		},
-		&CatalogServerId,
-		0, 0, 100,
-		NULL, NULL, NULL
-	},
-
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, 0, 0, 0, NULL, NULL, NULL
@@ -4344,6 +4333,17 @@ static struct config_string ConfigureNamesString[] =
 		},
 		&s3_url,
 		"127.0.0.1:9000",
+		NULL, NULL, NULL
+	},
+
+	{
+		{"catalog_server_id", PGC_POSTMASTER, PROCESS_TITLE,
+			gettext_noop("Sets the catalog server id of catalog server."),
+			NULL,
+			GUC_IS_NAME
+		},
+		&CatalogServerId,
+		"1",
 		NULL, NULL, NULL
 	},
 

--- a/src/bin/vmpool/cs_init.py
+++ b/src/bin/vmpool/cs_init.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import sys
 import remote_command
+import uuid
 
 def init_catalog_server(hostname, port, datadir, s3_url):
     gp_home = os.getenv("GPHOME")
@@ -11,26 +12,32 @@ def init_catalog_server(hostname, port, datadir, s3_url):
         print("PGHOME not set")
         sys.exit(1)
 
-    remote_command.create_minio_bucket("dbdata1", s3_url)
+    catalog_server_id = uuid.uuid4()
+    remote_command.create_minio_bucket("dbdata-%s" % str(catalog_server_id), s3_url)
     cmd = "%s/bin/initdb -D %s" %(gp_home, datadir)
     print("cmd: %s\n" % cmd)
     remote_command.command_run(cmd, hostname)
 
+
     remote_command.add_text_to_file(hostname, "%s/postgresql.conf" % datadir, "gp_contentid=-1")
     remote_command.add_text_to_file(hostname, "%s/internal.auto.conf" % datadir, "gp_dbid=1")
-    remote_command.add_text_to_file(hostname, "%s/internal.auto.conf" % datadir, "catalog_server_id=1")
+    remote_command.add_text_to_file(hostname, "%s/internal.auto.conf" % datadir,
+                                    "catalog_server_id=%s" % str(catalog_server_id))
     remote_command.add_text_to_file(hostname, "%s/internal.auto.conf" % datadir, "s3_url=%s" % s3_url)
 
-    cmd= "AWS_EC2_METADATA_DISABLED='true' PGOPTIONS='-c gp_role=utility -c default_table_access_method=heap' PGPORT=%d %s/bin/pg_ctl -D %s -l logfile start" % (port, gp_home, datadir)
+    cmd= ("AWS_EC2_METADATA_DISABLED='true' PGOPTIONS='-c gp_role=utility -c default_table_access_method=heap'"
+          " PGPORT=%d %s/bin/pg_ctl -D %s -l logfile start") % (port, gp_home, datadir)
     print("cmd: %s\n" % cmd)
     remote_command.command_run(cmd, hostname)
 
-    cmd = "PGOPTIONS='-c gp_role=utility -c default_table_access_method=heap' %s/bin/psql postgres -c 'select version()'" % (gp_home)
+    cmd = ("PGOPTIONS='-c gp_role=utility -c default_table_access_method=heap' %s/bin/psql postgres -c 'select version()'"
+           % (gp_home))
     print("cmd: %s\n" % cmd)
     remote_command.command_run(cmd, hostname)
 
     remote_command.add_text_to_file(hostname, "catalog_env.sh", "export PGPORT=%d" % port)
-    remote_command.add_text_to_file(hostname, "catalog_env.sh", "export PGOPTIONS='-c gp_role=utility -c default_table_access_method=heap'")
+    remote_command.add_text_to_file(hostname, "catalog_env.sh",
+                                    "export PGOPTIONS='-c gp_role=utility -c default_table_access_method=heap'")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -61,7 +68,6 @@ if __name__ == '__main__':
         type=str,
         help='the url of s3'
     )
-
 
     args = parser.parse_args()
 

--- a/src/bin/vmpool/cs_init.py
+++ b/src/bin/vmpool/cs_init.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+import time
 import remote_command
 import uuid
 
@@ -14,6 +15,7 @@ def init_catalog_server(hostname, port, datadir, s3_url):
 
     catalog_server_id = uuid.uuid4()
     remote_command.create_minio_bucket("dbdata-%s" % str(catalog_server_id), s3_url)
+    time.sleep(10)
     cmd = "%s/bin/initdb -D %s" %(gp_home, datadir)
     print("cmd: %s\n" % cmd)
     remote_command.command_run(cmd, hostname)

--- a/src/include/cdb/cdbcatalogfunc.h
+++ b/src/include/cdb/cdbcatalogfunc.h
@@ -56,6 +56,7 @@ extern bool accessTile;
 extern PGconn	*csConn;
 extern bool errorFromCatalogServer;
 extern char *cs_port;
+extern char *cs_host_name;
 
 typedef struct CdbCatalogAuxNode CdbCatalogAuxNode;
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -734,7 +734,7 @@ typedef struct GpId
  */
 extern GpId GpIdentity;
 extern int myClusterId;
-extern int CatalogServerId;
+extern char *CatalogServerId;
 extern int sessionClusterId;
 extern int cluster_size;
 

--- a/src/include/storage/objectfilerw.h
+++ b/src/include/storage/objectfilerw.h
@@ -47,7 +47,7 @@ extern uint32 S3GetObject2(void *s3Client, const char *bucketPath,
 extern void S3PutObject(void *s3Client, S3ObjKey s3_obj_key, S3Obj s3_obj);
 extern void S3DeleteObject(void *s3Client, char *objPath);
 extern bool S3BucketExist(void *s3Client, const char *bucketName);
-extern void S3SetBucketId(int id);
+extern void S3SetBucketId(char *id);
 
 #ifdef __cplusplus
 };

--- a/src/include/utils/dispatchcat.h
+++ b/src/include/utils/dispatchcat.h
@@ -86,7 +86,7 @@ typedef struct CdbCatalogNode
 	uint64	seq;
 	Oid 	namespace_1;
 	Oid 	namespace_2;
-	int 	CatalogServerId;
+	char   *CatalogServerId;
 	List   *tableList;
 	char   *s3Url;
 } CdbCatalogNode;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -25,6 +25,7 @@
 		"block_size",
 		"bonjour",
 		"bonjour_name",
+		"catalog_server_host",
 		"catalog_server_id",
 		"catalog_server_port",
 		"check_function_bodies",


### PR DESCRIPTION
The OCDB is designed for multiple users to share a VM pool. Each user
is assigned a dedicated catalog server. This commit allows users to 
configure the host and port through environment variables, enabling 
them to select their corresponding catalog server. 